### PR TITLE
Fixes I/O redirection bug in FreeRadius attack & f_Quit() adjustments

### DIFF
--- a/easy-creds.sh
+++ b/easy-creds.sh
@@ -1143,8 +1143,8 @@ if [ "${atheroscard}" -lt "1" ]; then
 	sleep 5
 fi
 
-mv ${pathtoradiusconf}/radiusd.conf ${pathtoradiusconf}/radiusd.conf.back 2&1> /dev/null
-mv ${pathtoradiusconf}/clients.conf ${pathtoradiusconf}/clients.conf.back 2&1> /dev/null
+mv ${pathtoradiusconf}/radiusd.conf ${pathtoradiusconf}/radiusd.conf.back 2>&1> /dev/null
+mv ${pathtoradiusconf}/clients.conf ${pathtoradiusconf}/clients.conf.back 2>&1> /dev/null
 
 if [ -e ${pathtoradiusconf} ]; then
 	cat ${pathtoradiusconf}/radiusd.conf.back | sed -e '/^proxy_request/s/yes/no/' -e 's/\$INCLUDE proxy.conf/#\$INCLUDE proxy.conf/' > ${pathtoradiusconf}/radiusd.conf

--- a/easy-creds.sh
+++ b/easy-creds.sh
@@ -113,7 +113,7 @@ if [ ! -z "$(pidof urlsnarf)" ]; then kill $(pidof urlsnarf); fi
 if [ ! -z "$(pidof dsniff)" ]; then kill $(pidof dsniff); fi
 echo "0" > /proc/sys/net/ipv4/ip_forward
 
-if [ -z "$(ls ${logfldr})" ];then rm -rf ${logfldr}; fi
+#if [ -z "$(ls ${logfldr})" ];then rm -rf ${logfldr}; fi #simple hack-fix for now
 # The following will run for wireless AP attacks
 if [ ! -z ${wireless} ]; then
 	kill $(pidof airbase-ng)


### PR DESCRIPTION
When spawning a FreeRadius AP an error was occuring during the 

`mv ${pathtoradiusconf}/radiusd.conf ${pathtoradiusconf}/radiusd.conf.back 2&1> /dev/null` command

I/O redirection should be `2>&1 ...` so I made the fix.

In the f_Quit() function easy-creds removes the log directory if a poisoning attack is stopped but if any further attacks are attempted the directory is now empty and thus causes issues. I just commented out the line in f_Quit() for the time being until an adequate solution is devised. When the exiting function is called all temporary directories will be cleaned up thus the clean up in f_Quit() after poisoning is not needed.

Thanks to [Karthik Rangarajan](https://github.com/karthikrangarajan) for originally pointing out these errors
